### PR TITLE
Switch QR flow to use UUID links

### DIFF
--- a/lib/helpers/deeplink_helper.dart
+++ b/lib/helpers/deeplink_helper.dart
@@ -1,30 +1,38 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
 import 'package:nompangs/services/character_manager.dart';
 
 class DeepLinkHelper {
   static Future<Map<String, dynamic>?> processCharacterData(
-    String encodedData,
+    String uuid,
   ) async {
     final String platform = defaultTargetPlatform.name;
+    final baseUrl = dotenv.env['QR_API_BASE_URL'] ?? 'http://localhost:8080';
     try {
-      final decodedData = utf8.decode(base64Url.decode(encodedData));
-      final characterData = jsonDecode(decodedData) as Map<String, dynamic>;
+      final response = await http.get(Uri.parse('$baseUrl/loadQR/$uuid'));
+      if (response.statusCode != 200) {
+        print('[DeepLinkHelper][$platform] loadQR 실패: ${response.statusCode}');
+        return null;
+      }
+      final characterData = jsonDecode(response.body) as Map<String, dynamic>;
 
       if (!_isValidCharacterData(characterData)) {
-        print(
-          '[DeepLinkHelper][$platform] processCharacterData: 유효하지 않은 캐릭터 데이터 형식.',
-        );
+        print('[DeepLinkHelper][$platform] 유효하지 않은 캐릭터 데이터 형식.');
         return null;
       }
 
-      final personaId = await CharacterManager.instance.handleCharacterFromQR(
-        characterData,
-      );
-      print(
-        '[DeepLinkHelper][$platform] Firebase에 캐릭터 저장 완료. personaId: $personaId',
-      );
+      final personaId = characterData['personaId'] as String?;
+      if (personaId == null) {
+        print('[DeepLinkHelper][$platform] personaId 누락');
+        return null;
+      }
+
+      await CharacterManager.instance.handleCharacterFromQR(personaId);
+      print('[DeepLinkHelper][$platform] 사용자-캐릭터 관계 생성 완료');
 
       return {
         'characterName': characterData['name'] as String,
@@ -33,9 +41,7 @@ class DeepLinkHelper {
         'personaId': personaId,
       };
     } catch (e, s) {
-      print(
-        '[DeepLinkHelper][$platform] processCharacterData: 딥링크 데이터 처리 중 오류: $e',
-      );
+      print('[DeepLinkHelper][$platform] 데이터 처리 중 오류: $e');
       print('[DeepLinkHelper][$platform] Stacktrace: $s');
       return null;
     }
@@ -45,8 +51,10 @@ class DeepLinkHelper {
     final isValid =
         data.containsKey('name') &&
         data.containsKey('tags') &&
+        data.containsKey('personaId') &&
         data['name'] is String &&
-        data['tags'] is List;
+        data['tags'] is List &&
+        data['personaId'] is String;
 
     return isValid;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -129,12 +129,12 @@ class _NompangsAppState extends State<NompangsApp> {
 
   void _handleDeepLink(Uri uri) async {
     final roomId = uri.queryParameters['roomId'];
-    final encodedData = uri.queryParameters['data'];
+    final uuid = uri.queryParameters['id'];
     print('📦 딥링크 수신됨! URI: $uri, roomId: $roomId');
 
     if (roomId != null) {
-      if (encodedData != null) {
-        final chatData = await DeepLinkHelper.processCharacterData(encodedData);
+      if (uuid != null) {
+        final chatData = await DeepLinkHelper.processCharacterData(uuid);
 
         if (chatData != null) {
           _navigatorKey.currentState?.pushNamed(
@@ -148,7 +148,7 @@ class _NompangsAppState extends State<NompangsApp> {
           );
         }
       } else {
-        // data 파라미터가 없는 경우
+        // id 파라미터가 없는 경우
         DeepLinkHelper.showError(
             _navigatorKey.currentContext!,
             '캐릭터 정보가 없는 QR 코드입니다.'

--- a/lib/screens/main/qr_scanner_screen.dart
+++ b/lib/screens/main/qr_scanner_screen.dart
@@ -38,24 +38,24 @@ class _QRScannerScreenState extends State<QRScannerScreen> {
 
 
     Map<String, dynamic>? chatData;
-    String? encodedDataFromQR;
+    String? uuidFromQR;
 
     try {
       final uri = Uri.tryParse(code);
       if (uri != null) {
-        encodedDataFromQR = uri.queryParameters['data'];
+        uuidFromQR = uri.queryParameters['id'];
       }
 
-      if (encodedDataFromQR != null) {
-        chatData = await DeepLinkHelper.processCharacterData(encodedDataFromQR)
+      if (uuidFromQR != null) {
+        chatData = await DeepLinkHelper.processCharacterData(uuidFromQR)
             .timeout(const Duration(seconds: 20), onTimeout: () {
           print('[QRScanner][${defaultTargetPlatform.name}] _handleQRCode: DeepLinkHelper.processCharacterData 타임아웃.');
           if (mounted) _showError('캐릭터 정보 처리 시간이 초과되었습니다.');
           return null;
         });
       } else {
-        // encodedDataFromQR이 null이면 사용자에게 알림
-        if (mounted) _showError('QR 코드에서 데이터를 읽을 수 없습니다.');
+        // uuidFromQR이 null이면 사용자에게 알림
+        if (mounted) _showError('QR 코드에서 UUID를 읽을 수 없습니다.');
       }
 
       if (chatData != null && mounted) {
@@ -72,7 +72,7 @@ class _QRScannerScreenState extends State<QRScannerScreen> {
         );
         return; 
       } else {
-          if (mounted && encodedDataFromQR != null && chatData == null) {
+          if (mounted && uuidFromQR != null && chatData == null) {
         }
       }
     } catch (e, s) {


### PR DESCRIPTION
## Summary
- update CharacterManager to create QR profiles through a Cloud Function
- save onboarding QR codes via `saveCharacterForQR`
- parse UUID links in `DeepLinkHelper` and QR scanner
- update onboarding completion screen to show QR codes with UUID links
- revert changes to unused `character_complete_screen.dart`

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_684670b5cef4833196cdd6a177a180f1