### PR TITLE
Enable cleartext traffic for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ This Flutter application powers the Nompangs experience. It relies on Firebase f
   ```bash
   flutter analyze
   ```
+
+### Android Notes
+
+The QR code backend currently uses HTTP. Recent Android versions block cleartext traffic unless explicitly allowed. The manifest sets `android:usesCleartextTraffic="true"` so the app can reach the backend during development. Remove this setting or switch the backend to HTTPS before releasing.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
 <application
         android:label="product"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- allow HTTP requests on Android by setting `usesCleartextTraffic`
- document the cleartext traffic requirement in the README

## Testing
- `flutter test` *(fails: flutter not installed)*
- `flutter build apk` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc7a09908331bbd31ceb089c14db