### PR TITLE
Handle QR creation errors

### DIFF
--- a/lib/screens/character/character_complete_screen.dart
+++ b/lib/screens/character/character_complete_screen.dart
@@ -49,6 +49,20 @@ class _CharacterCompleteScreenState extends State<CharacterCompleteScreen> {
       if (mounted) setState(() => _qrUuid = uuid);
     } catch (e) {
       print('QR 생성 실패: $e');
+      if (mounted) {
+        String message = 'QR 생성 실패';
+        final match = RegExp(r'(\d{3})').firstMatch(e.toString());
+        if (match != null) {
+          message = 'QR 생성 실패 (HTTP ${match.group(1)})';
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(message),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
     } finally {
       if (mounted) setState(() => _loading = false);
     }

--- a/lib/screens/onboarding/onboarding_completion_screen.dart
+++ b/lib/screens/onboarding/onboarding_completion_screen.dart
@@ -115,6 +115,20 @@ class _OnboardingCompletionScreenState extends State<OnboardingCompletionScreen>
       }
     } catch (e) {
       print('QR 생성 실패: $e');
+      if (mounted) {
+        String message = 'QR 생성 실패';
+        final match = RegExp(r'(\d{3})').firstMatch(e.toString());
+        if (match != null) {
+          message = 'QR 생성 실패 (HTTP ${match.group(1)})';
+        }
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(message),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
     } finally {
       if (mounted) {
         setState(() {


### PR DESCRIPTION
## Summary
- show a SnackBar if QR creation fails in onboarding or character finish screens
- include HTTP code when available

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849376775108331b37650aae16e1357