### PR TITLE
Populate QR profile sections

### DIFF
--- a/lib/models/personality_profile.dart
+++ b/lib/models/personality_profile.dart
@@ -1,0 +1,43 @@
+class PersonalityProfile {
+  final String aiPersonalityProfile;
+  final String photoAnalysis;
+  final String lifeStory;
+  final String humorMatrix;
+  final String attractiveFlaws;
+  final String contradictions;
+  final String communicationStyle;
+  final String structuredPrompt;
+
+  const PersonalityProfile({
+    required this.aiPersonalityProfile,
+    required this.photoAnalysis,
+    required this.lifeStory,
+    required this.humorMatrix,
+    required this.attractiveFlaws,
+    required this.contradictions,
+    required this.communicationStyle,
+    required this.structuredPrompt,
+  });
+
+  factory PersonalityProfile.empty() => const PersonalityProfile(
+        aiPersonalityProfile: '',
+        photoAnalysis: '',
+        lifeStory: '',
+        humorMatrix: '',
+        attractiveFlaws: '',
+        contradictions: '',
+        communicationStyle: '',
+        structuredPrompt: '',
+      );
+
+  Map<String, String> toMap() => {
+        'aiPersonalityProfile': aiPersonalityProfile,
+        'photoAnalysis': photoAnalysis,
+        'lifeStory': lifeStory,
+        'humorMatrix': humorMatrix,
+        'attractiveFlaws': attractiveFlaws,
+        'contradictions': contradictions,
+        'communicationStyle': communicationStyle,
+        'structuredPrompt': structuredPrompt,
+      };
+}

--- a/lib/providers/onboarding_provider.dart
+++ b/lib/providers/onboarding_provider.dart
@@ -1,38 +1,63 @@
 import 'package:flutter/foundation.dart';
 import 'package:nompangs/models/onboarding_state.dart';
+import 'package:nompangs/models/personality_profile.dart';
 import 'dart:math';
+import 'dart:convert';
 
 class OnboardingProvider extends ChangeNotifier {
   OnboardingState _state = const OnboardingState();
+  PersonalityProfile _profile = PersonalityProfile.empty();
+
+  PersonalityProfile get personalityProfile => _profile;
   
   OnboardingState get state => _state;
   
   void nextStep() {
     _state = _state.copyWith(currentStep: _state.currentStep + 1);
     notifyListeners();
+    debugPrint('=== Onboarding Status [nextStep] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   void setUserInput(UserInput input) {
     _state = _state.copyWith(userInput: input);
     notifyListeners();
+    debugPrint('=== Onboarding Status [setUserInput] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   /// 용도 업데이트 (Step 3)
   void updatePurpose(String purpose) {
     _state = _state.copyWith(purpose: purpose);
     notifyListeners();
+    debugPrint('=== Onboarding Status [updatePurpose] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   /// 유머스타일 업데이트 (Step 3)
   void updateHumorStyle(String style) {
     _state = _state.copyWith(humorStyle: style);
     notifyListeners();
+    debugPrint('=== Onboarding Status [updateHumorStyle] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   /// 사진 경로 업데이트 (Step 4)
   void updatePhotoPath(String? path) {
     _state = _state.copyWith(photoPath: path);
     notifyListeners();
+    debugPrint('=== Onboarding Status [updatePhotoPath] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   /// 성격 슬라이더 업데이트 (Step 6)
@@ -49,32 +74,56 @@ class OnboardingProvider extends ChangeNotifier {
         break;
     }
     notifyListeners();
+    debugPrint('=== Onboarding Status [updatePersonalitySlider] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   /// QR 코드 URL 업데이트 (완료 단계)
   void updateQRCodeUrl(String url) {
     _state = _state.copyWith(qrCodeUrl: url);
     notifyListeners();
+    debugPrint('=== Onboarding Status [updateQRCodeUrl] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   void setPhotoPath(String path) {
     _state = _state.copyWith(photoPath: path);
     notifyListeners();
+    debugPrint('=== Onboarding Status [setPhotoPath] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   void setGeneratedCharacter(Character character) {
     _state = _state.copyWith(generatedCharacter: character);
     notifyListeners();
+    debugPrint('=== Onboarding Status [setGeneratedCharacter] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   void setError(String error) {
     _state = _state.copyWith(errorMessage: error, isLoading: false);
     notifyListeners();
+    debugPrint('=== Onboarding Status [setError] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   void clearError() {
     _state = _state.copyWith(errorMessage: null);
     notifyListeners();
+    debugPrint('=== Onboarding Status [clearError] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
   
   Future<void> generateCharacter() async {
@@ -89,6 +138,10 @@ class OnboardingProvider extends ChangeNotifier {
       generationMessage: "캐릭터 깨우는 중..."
     );
     notifyListeners();
+    debugPrint("=== Onboarding Status [startGenerateCharacter] ===");
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint("===============================");
     
     try {
       // 3단계 시뮬레이션 (Figma 정확)
@@ -105,6 +158,10 @@ class OnboardingProvider extends ChangeNotifier {
         generationProgress: 1.0,
       );
       notifyListeners();
+    debugPrint("=== Onboarding Status [generateCharacterComplete] ===");
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint("===============================");
       
     } catch (e) {
       _state = _state.copyWith(
@@ -112,6 +169,10 @@ class OnboardingProvider extends ChangeNotifier {
         errorMessage: '캐릭터 생성 중 오류가 발생했습니다: $e'
       );
       notifyListeners();
+    debugPrint("=== Onboarding Status [generateCharacterError] ===");
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint("===============================");
     }
   }
   
@@ -123,6 +184,10 @@ class OnboardingProvider extends ChangeNotifier {
         generationMessage: message,
       );
       notifyListeners();
+      debugPrint("=== Onboarding Status [simulateProgress] ===");
+      debugPrint(jsonEncode(_state.toJson()));
+      debugPrint(jsonEncode(_profile.toMap()));
+      debugPrint("===============================");
     }
   }
   
@@ -224,10 +289,28 @@ class OnboardingProvider extends ChangeNotifier {
     
     _state = _state.copyWith(generatedCharacter: updatedCharacter);
     notifyListeners();
+    debugPrint('=== Onboarding Status [updatePersonality] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
-  
+
+  void setPersonalityProfile(PersonalityProfile profile) {
+    _profile = profile;
+    notifyListeners();
+    debugPrint('=== Onboarding Status [setPersonalityProfile] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
+  }
+
   void reset() {
     _state = const OnboardingState();
+    _profile = PersonalityProfile.empty();
     notifyListeners();
+    debugPrint('=== Onboarding Status [reset] ===');
+    debugPrint(jsonEncode(_state.toJson()));
+    debugPrint(jsonEncode(_profile.toMap()));
+    debugPrint('===============================');
   }
-} 
+}

--- a/lib/screens/onboarding/onboarding_completion_screen.dart
+++ b/lib/screens/onboarding/onboarding_completion_screen.dart
@@ -85,6 +85,8 @@ class _OnboardingCompletionScreenState extends State<OnboardingCompletionScreen>
     setState(() {
       _creatingQr = true;
     });
+    final providerState = context.read<OnboardingProvider>();
+    final profile = providerState.personalityProfile;
     final data = {
       'name': character.name,
       'tags': character.traits,
@@ -94,7 +96,15 @@ class _OnboardingCompletionScreenState extends State<OnboardingCompletionScreen>
         'warmth': character.personality.warmth,
         'competence': character.personality.competence,
         'extroversion': character.personality.extroversion,
-      }
+      },
+      'aiPersonalityProfile': profile.aiPersonalityProfile,
+      'photoAnalysis': profile.photoAnalysis,
+      'lifeStory': profile.lifeStory,
+      'humorMatrix': profile.humorMatrix,
+      'attractiveFlaws': profile.attractiveFlaws,
+      'contradictions': profile.contradictions,
+      'communicationStyle': profile.communicationStyle,
+      'structuredPrompt': profile.structuredPrompt,
     };
     try {
       final uuid = await CharacterManager.instance.saveCharacterForQR(data);

--- a/lib/screens/onboarding/onboarding_personality_screen.dart
+++ b/lib/screens/onboarding/onboarding_personality_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:nompangs/providers/onboarding_provider.dart';
 import 'package:nompangs/models/onboarding_state.dart';
+import 'package:nompangs/services/personality_service.dart';
 
 class OnboardingPersonalityScreen extends StatefulWidget {
   const OnboardingPersonalityScreen({Key? key}) : super(key: key);
@@ -205,8 +206,15 @@ class _OnboardingPersonalityScreenState
                       border: Border.all(color: Colors.grey.shade400, width: 1),
                     ),
                     child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.pushNamed(context, '/onboarding/completion');
+                      onPressed: () async {
+                        final provider = context.read<OnboardingProvider>();
+                        final service = const PersonalityService();
+                        final profile =
+                            await service.generateProfile(provider.state);
+                        provider.setPersonalityProfile(profile);
+                        if (mounted) {
+                          Navigator.pushNamed(context, '/onboarding/completion');
+                        }
                       },
                       style: ElevatedButton.styleFrom(
                         backgroundColor: Colors.white,

--- a/lib/services/personality_service.dart
+++ b/lib/services/personality_service.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import '../models/onboarding_state.dart';
+import '../models/personality_profile.dart';
+
+class PersonalityService {
+  const PersonalityService();
+
+  /// GPT API를 사용해 성격 프로필을 생성합니다.
+  Future<PersonalityProfile> generateProfile(OnboardingState state) async {
+    final userInput = state.userInput;
+    if (userInput == null) return PersonalityProfile.empty();
+
+    final apiKey = dotenv.env['OPENAI_API_KEY'];
+    if (apiKey == null || apiKey.isEmpty) {
+      return buildInitialProfile(state);
+    }
+
+    final introversion = state.introversion ?? 5;
+    final warmth = state.warmth ?? 5;
+    final competence = state.competence ?? 5;
+
+    final systemPrompt = '''
+다음 사용자 정보를 활용해 AI 캐릭터 프로필을 JSON으로 만들어줘.
+모든 필드는 한글로 작성하고 한 문단으로 요약해.
+필드 목록: aiPersonalityProfile, photoAnalysis, lifeStory, humorMatrix,
+attractiveFlaws, contradictions, communicationStyle, structuredPrompt.
+''';
+
+    final userPrompt = '''
+이름:${userInput.nickname}, 위치:${userInput.location}, 기간:${userInput.duration},
+사물:${userInput.objectType}, 용도:${state.purpose}, 유머:${state.humorStyle},
+내향성:$introversion, 따뜻함:$warmth, 능숙함:$competence.
+''';
+
+    final uri = Uri.parse('https://api.openai.com/v1/chat/completions');
+    final headers = {
+      'Content-Type': 'application/json; charset=UTF-8',
+      'Authorization': 'Bearer $apiKey',
+    };
+
+    final body = jsonEncode({
+      'model': 'gpt-4o-mini',
+      'messages': [
+        {'role': 'system', 'content': systemPrompt},
+        {'role': 'user', 'content': userPrompt},
+      ],
+      'temperature': 0.7,
+      'max_tokens': 800,
+    });
+
+    try {
+      final response = await http.post(uri, headers: headers, body: body);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(utf8.decode(response.bodyBytes));
+        final text = data['choices'][0]['message']['content'] as String?;
+        if (text != null) {
+          final jsonStart = text.indexOf('{');
+          final jsonEnd = text.lastIndexOf('}');
+          if (jsonStart != -1 && jsonEnd != -1) {
+            final jsonString = text.substring(jsonStart, jsonEnd + 1);
+            final Map<String, dynamic> map = jsonDecode(jsonString);
+            return PersonalityProfile(
+              aiPersonalityProfile: map['aiPersonalityProfile'] ?? '',
+              photoAnalysis: map['photoAnalysis'] ?? '',
+              lifeStory: map['lifeStory'] ?? '',
+              humorMatrix: map['humorMatrix'] ?? '',
+              attractiveFlaws: map['attractiveFlaws'] ?? '',
+              contradictions: map['contradictions'] ?? '',
+              communicationStyle: map['communicationStyle'] ?? '',
+              structuredPrompt: map['structuredPrompt'] ?? '',
+            );
+          }
+        }
+      }
+    } catch (_) {
+      // ignore - 실패 시 기본 프로필 사용
+    }
+
+    return buildInitialProfile(state);
+  }
+
+  PersonalityProfile buildInitialProfile(OnboardingState state) {
+    final userInput = state.userInput;
+    if (userInput == null) return PersonalityProfile.empty();
+
+    final introversion = state.introversion ?? 5;
+    final warmth = state.warmth ?? 5;
+    final competence = state.competence ?? 5;
+    final purpose = state.purpose;
+    final humorStyle = state.humorStyle;
+
+    final aiPersonalityProfile =
+        '${userInput.nickname}의 $purpose를 돕는 ${userInput.objectType}. 성격은 '
+        '내향성 $introversion/10, 따뜻함 $warmth/10, 능숙함 $competence/10.';
+    final photoAnalysis = state.photoPath != null
+        ? '사진 속 ${userInput.objectType}의 매력이 잘 드러나.'
+        : '아직 사진이 없어.';
+    final lifeStory = '${userInput.location}에서 ${userInput.duration} 동안 지냈어.';
+    final humorMatrix = '주된 유머 스타일은 $humorStyle.';
+    final attractiveFlaws =
+        warmth >= 6 ? '가끔 지나치게 다정해.' : '조금 무뚝뚝해.';
+    final contradictions = introversion > 5
+        ? '활발하지만 내성적이기도 해.'
+        : '조용하지만 가끔 대담해.';
+    final communicationStyle = introversion > 5
+        ? '말이 많고 직설적이야.'
+        : '짧고 조심스러운 편이야.';
+    final structuredPrompt =
+        '이름:${userInput.nickname}, 목적:$purpose, 유머:$humorStyle, '
+        '내향성:$introversion, 따뜻함:$warmth, 능숙함:$competence.';
+
+    return PersonalityProfile(
+      aiPersonalityProfile: aiPersonalityProfile,
+      photoAnalysis: photoAnalysis,
+      lifeStory: lifeStory,
+      humorMatrix: humorMatrix,
+      attractiveFlaws: attractiveFlaws,
+      contradictions: contradictions,
+      communicationStyle: communicationStyle,
+      structuredPrompt: structuredPrompt,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- generate personality data using OpenAI in `PersonalityService`
- save personality profile in provider and include it when creating QR payload
- log onboarding state and profile on every change
- fix missing newline in provider file

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849234d8b3083319f0ebd066cbf91d7